### PR TITLE
Fixed Chrome on Mac throwing "i is not defined"

### DIFF
--- a/lz-string.js
+++ b/lz-string.js
@@ -126,6 +126,7 @@ var LZString = {
         numBits = 3,
         entry = "",
         result = "",
+        i,
         w,
         c,
         errorCount=0,


### PR DESCRIPTION
Very minor issue, great tool!  Decompress() was missing the `i` variable declaration on the for loop.
