### PR TITLE
Letting localstore data that is null pass through

### DIFF
--- a/libs/lz-string-1.3.0-rc1.js
+++ b/libs/lz-string-1.3.0-rc1.js
@@ -494,6 +494,9 @@ var LZString = {
   },
   
   decompress: function (compressed) {
+    if (compressed === null){
+      return null;
+     }
     var dictionary = [],
         next,
         enlargeIn = 4,


### PR DESCRIPTION
Hi, my first attempt at a pull request. When using your library it stopped on compressed having the value null, maybe because a key was read from localstorage that did not exist. I put in a check to see if compressed is null and in that case just let null pass through.
