### PR TITLE
Add a sanity check to partially-correct input

### DIFF
--- a/libs/lz-string-1.3.3.js
+++ b/libs/lz-string-1.3.3.js
@@ -568,6 +568,10 @@ var LZString = {
     dictionary[3] = c;
     w = result = c;
     while (true) {
+      if (data.index > data.string.length) {
+        return "";
+      }
+      
       bits = 0;
       maxpower = Math.pow(2,numBits);
       power=1;


### PR DESCRIPTION
I was generating compressed base64 strings of the form "abc/def". I
accidentally tried decompressing just the "abc" portion of the string,
causing decompress() to hang indefinitely. This index/length check
prevents that case.
