### PR TITLE
Simplify UTF16 Conversion

### DIFF
--- a/libs/lz-string.js
+++ b/libs/lz-string.js
@@ -121,66 +121,22 @@ var LZString = {
     
     for (i=0 ; i<input.length ; i++) {
       c = input.charCodeAt(i);
-      switch (status++) {
+      switch (status) {
         case 0:
           output += f((c >> 1)+32);
           current = (c & 1) << 14;
+          status++;
           break;
-        case 1:
-          output += f((current + (c >> 2))+32);
-          current = (c & 3) << 13;
-          break;
-        case 2:
-          output += f((current + (c >> 3))+32);
-          current = (c & 7) << 12;
-          break;
-        case 3:
-          output += f((current + (c >> 4))+32);
-          current = (c & 15) << 11;
-          break;
-        case 4:
-          output += f((current + (c >> 5))+32);
-          current = (c & 31) << 10;
-          break;
-        case 5:
-          output += f((current + (c >> 6))+32);
-          current = (c & 63) << 9;
-          break;
-        case 6:
-          output += f((current + (c >> 7))+32);
-          current = (c & 127) << 8;
-          break;
-        case 7:
-          output += f((current + (c >> 8))+32);
-          current = (c & 255) << 7;
-          break;
-        case 8:
-          output += f((current + (c >> 9))+32);
-          current = (c & 511) << 6;
-          break;
-        case 9:
-          output += f((current + (c >> 10))+32);
-          current = (c & 1023) << 5;
-          break;
-        case 10:
-          output += f((current + (c >> 11))+32);
-          current = (c & 2047) << 4;
-          break;
-        case 11:
-          output += f((current + (c >> 12))+32);
-          current = (c & 4095) << 3;
-          break;
-        case 12:
-          output += f((current + (c >> 13))+32);
-          current = (c & 8191) << 2;
-          break;
-        case 13:
-          output += f((current + (c >> 14))+32);
-          current = (c & 16383) << 1;
-          break;
+
         case 14:
           output += f((current + (c >> 15))+32, (c & 32767)+32);
           status = 0;
+          break;
+
+        default:
+          output += f((current + (c >> (status + 1)))+32);
+          current = (c & ((2 << status) - 1)) << (14 - status);
+          status++;
           break;
       }
     }


### PR DESCRIPTION
Simplified the switch statement for UTF16 Conversion. Reduces cyclomatic complexity from 18 to 5.

http://jsperf.com/lzstring-utf-complex

Not sure why the desktop Safari numbers are off. Mobile Safari was faster, for me.