### PR TITLE
Fix decompressFromUint8Array, replace .apply() with forEach

### DIFF
--- a/libs/lz-string.js
+++ b/libs/lz-string.js
@@ -262,8 +262,8 @@ var LZString = {
 
         var result = "";
         buf.forEach(function (c) {
-		result = result + String.fromCharCode(c);
-	    });
+	  result = result + String.fromCharCode(c);
+	});
         return LZString.decompress(result);
 
     }

--- a/libs/lz-string.js
+++ b/libs/lz-string.js
@@ -260,7 +260,11 @@ var LZString = {
           buf[i]=compressed[i*2]*256+compressed[i*2+1];
         }
 
-        return LZString.decompress(String.fromCharCode.apply(null, buf));
+        var result = "";
+        buf.forEach(function (c) {
+		result = result + String.fromCharCode(c);
+	    });
+        return LZString.decompress(result);
 
     }
 


### PR DESCRIPTION
The original .apply() was overflowing the call stack.  Switched to a forEach.