### PR TITLE
Add support for in-browser use with AMD loaders

### DIFF
--- a/libs/lz-string.js
+++ b/libs/lz-string.js
@@ -494,6 +494,8 @@ var LZString = {
   return LZString;
 })();
 
-if( typeof module !== 'undefined' && module != null ) {
+if (typeof define === 'function' && define.amd) {
+  define(function () { return LZString; });
+} else if( typeof module !== 'undefined' && module != null ) {
   module.exports = LZString
 }


### PR DESCRIPTION
This change allows using the library from within the browser when using AMD loaders such as require.js while still maintaining commonJS calls intact.