### PR TITLE
decompressFromUint8Array optimisation

### DIFF
--- a/libs/lz-string.js
+++ b/libs/lz-string.js
@@ -73,19 +73,11 @@ var LZString = {
     if (compressed===null || compressed===undefined){
         return LZString.decompress(compressed);
     } else {
-        var buf=new Array(compressed.length/2); // 2 bytes per character
-        for (var i=0, TotalLen=buf.length; i<TotalLen; i++) {
-          buf[i]=compressed[i*2]*256+compressed[i*2+1];
+        for (var i=0, TotalLen=compressed.length/2, result=[]; i<TotalLen; i++) {
+          result.push(f(compressed[i*2]*256+compressed[i*2+1]));
         }
-
-        var result = [];
-        buf.forEach(function (c) {
-          result.push(f(c));
-        });
         return LZString.decompress(result.join(''));
-
     }
-
   },
 
 


### PR DESCRIPTION
Remove the redundant temporary buffer, and push the output character directly into the output buffer. This saves memory and is quicker as it doesn't need to iterate twice.

(Minified version not updated as edited on GitHub directly)
