### PR TITLE
TypeScript: adjust reference module declaration

### DIFF
--- a/typings/lz-string.d.ts
+++ b/typings/lz-string.d.ts
@@ -1,16 +1,16 @@
-declare module LZString {
-  function compressToBase64(input: string): string;
-  function decompressFromBase64(input: string): string;
+declare module "LZString" {
+  export function compressToBase64(input: string): string;
+  export function decompressFromBase64(input: string): string;
 
-  function compressToUTF16(input: string): string;
-  function decompressFromUTF16(compressed: string): string;
+  export function compressToUTF16(input: string): string;
+  export function decompressFromUTF16(compressed: string): string;
 
-  function compressToUint8Array(uncompressed: string): Uint8Array;
-  function decompressFromUint8Array(compressed: Uint8Array): string;
+  export function compressToUint8Array(uncompressed: string): Uint8Array;
+  export function decompressFromUint8Array(compressed: Uint8Array): string;
 
-  function compressToEncodedURIComponent(input: string): string;
-  function decompressFromEncodedURIComponent(compressed: string): string;
+  export function compressToEncodedURIComponent(input: string): string;
+  export function decompressFromEncodedURIComponent(compressed: string): string;
 
-  function compress(input: string): string;
-  function decompress(compressed: string): string;
+  export function compress(input: string): string;
+  export function decompress(compressed: string): string;
 }


### PR DESCRIPTION
importing lz-script on TypeScript:

`/// <reference path="node_modules/lz-string/typings/lz-string.d.ts" />`
`import * as LZString from 'LZString';`

 is getting error:

> error TS2307: Cannot find module 'LZString'

now, checking documentation (https://www.typescriptlang.org/docs/handbook/namespaces-and-modules.html#pitfalls-of-namespaces-and-modules) and updating the format in lz-string.d.ts, the TS compiler it's not showing anymore the import error