### PR TITLE
Make typings work out-of-the-box

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "string"
   ],
   "main": "libs/lz-string.js",
+  "typings": "typings/lz-string.d.ts",
   "bin": {
     "lz-string": "bin/bin.js"
   },

--- a/typings/lz-string.d.ts
+++ b/typings/lz-string.d.ts
@@ -1,16 +1,14 @@
-declare module LZString {
-  function compressToBase64(input: string): string;
-  function decompressFromBase64(input: string): string;
+export function compressToBase64(input: string): string;
+export function decompressFromBase64(input: string): string;
 
-  function compressToUTF16(input: string): string;
-  function decompressFromUTF16(compressed: string): string;
+export function compressToUTF16(input: string): string;
+export function decompressFromUTF16(compressed: string): string;
 
-  function compressToUint8Array(uncompressed: string): Uint8Array;
-  function decompressFromUint8Array(compressed: Uint8Array): string;
+export function compressToUint8Array(uncompressed: string): Uint8Array;
+export function decompressFromUint8Array(compressed: Uint8Array): string;
 
-  function compressToEncodedURIComponent(input: string): string;
-  function decompressFromEncodedURIComponent(compressed: string): string;
+export function compressToEncodedURIComponent(input: string): string;
+export function decompressFromEncodedURIComponent(compressed: string): string;
 
-  function compress(input: string): string;
-  function decompress(compressed: string): string;
-}
+export function compress(input: string): string;
+export function decompress(compressed: string): string;


### PR DESCRIPTION
This makes the typings work out-of-the-box.

```typescript
import * as LZString from 'lz-string';
const compressed = LZString.compressToBase64('My string');
```