### PR TITLE
Array lookup + avoid intermediate string creation

### DIFF
--- a/libs/base64-string.js
+++ b/libs/base64-string.js
@@ -9,6 +9,19 @@
 //
 // Base64 compression / decompression for already compressed content (gif, png, jpg, mp3, ...)
 // version 1.4.1
+
+var Base64String = (function(){
+var f = String.fromCharCode;
+var keyStrEnc = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".split('');
+var keyStrDec = (function (){
+    var dict = {}
+    var i = keyStrEnc.length;
+    while(i--){
+      dict[keyStrEnc[i]] = i;
+    }
+    return dict;
+  })();
+
 var Base64String = {
 
   compressToUTF16 : function (input) {
@@ -23,68 +36,68 @@ var Base64String = {
       c = input.charCodeAt(i);
       switch (status++) {
         case 0:
-          output.push(String.fromCharCode((c >> 1)+32));
+          output.push(f((c >> 1)+32));
           current = (c & 1) << 14;
           break;
         case 1:
-          output.push(String.fromCharCode((current + (c >> 2))+32));
+          output.push(f((current + (c >> 2))+32));
           current = (c & 3) << 13;
           break;
         case 2:
-          output.push(String.fromCharCode((current + (c >> 3))+32));
+          output.push(f((current + (c >> 3))+32));
           current = (c & 7) << 12;
           break;
         case 3:
-          output.push(String.fromCharCode((current + (c >> 4))+32));
+          output.push(f((current + (c >> 4))+32));
           current = (c & 15) << 11;
           break;
         case 4:
-          output.push(String.fromCharCode((current + (c >> 5))+32));
+          output.push(f((current + (c >> 5))+32));
           current = (c & 31) << 10;
           break;
         case 5:
-          output.push(String.fromCharCode((current + (c >> 6))+32));
+          output.push(f((current + (c >> 6))+32));
           current = (c & 63) << 9;
           break;
         case 6:
-          output.push(String.fromCharCode((current + (c >> 7))+32));
+          output.push(f((current + (c >> 7))+32));
           current = (c & 127) << 8;
           break;
         case 7:
-          output.push(String.fromCharCode((current + (c >> 8))+32));
+          output.push(f((current + (c >> 8))+32));
           current = (c & 255) << 7;
           break;
         case 8:
-          output.push(String.fromCharCode((current + (c >> 9))+32));
+          output.push(f((current + (c >> 9))+32));
           current = (c & 511) << 6;
           break;
         case 9:
-          output.push(String.fromCharCode((current + (c >> 10))+32));
+          output.push(f((current + (c >> 10))+32));
           current = (c & 1023) << 5;
           break;
         case 10:
-          output.push(String.fromCharCode((current + (c >> 11))+32));
+          output.push(f((current + (c >> 11))+32));
           current = (c & 2047) << 4;
           break;
         case 11:
-          output.push(String.fromCharCode((current + (c >> 12))+32));
+          output.push(f((current + (c >> 12))+32));
           current = (c & 4095) << 3;
           break;
         case 12:
-          output.push(String.fromCharCode((current + (c >> 13))+32));
+          output.push(f((current + (c >> 13))+32));
           current = (c & 8191) << 2;
           break;
         case 13:
-          output.push(String.fromCharCode((current + (c >> 14))+32));
+          output.push(f((current + (c >> 14))+32));
           current = (c & 16383) << 1;
           break;
         case 14:
-          output.push(String.fromCharCode((current + (c >> 15))+32, (c & 32767)+32));
+          output.push(f((current + (c >> 15))+32, (c & 32767)+32));
           status = 0;
           break;
       }
     }
-    output.push(String.fromCharCode(current + 32));
+    output.push(f(current + 32));
     return output.join('');
   },
 
@@ -103,63 +116,63 @@ var Base64String = {
           current = c << 1;
           break;
         case 1:
-          output.push(String.fromCharCode(current | (c >> 14)));
+          output.push(f(current | (c >> 14)));
           current = (c&16383) << 2;
           break;
         case 2:
-          output.push(String.fromCharCode(current | (c >> 13)));
+          output.push(f(current | (c >> 13)));
           current = (c&8191) << 3;
           break;
         case 3:
-          output.push(String.fromCharCode(current | (c >> 12)));
+          output.push(f(current | (c >> 12)));
           current = (c&4095) << 4;
           break;
         case 4:
-          output.push(String.fromCharCode(current | (c >> 11)));
+          output.push(f(current | (c >> 11)));
           current = (c&2047) << 5;
           break;
         case 5:
-          output.push(String.fromCharCode(current | (c >> 10)));
+          output.push(f(current | (c >> 10)));
           current = (c&1023) << 6;
           break;
         case 6:
-          output.push(String.fromCharCode(current | (c >> 9)));
+          output.push(f(current | (c >> 9)));
           current = (c&511) << 7;
           break;
         case 7:
-          output.push(String.fromCharCode(current | (c >> 8)));
+          output.push(f(current | (c >> 8)));
           current = (c&255) << 8;
           break;
         case 8:
-          output.push(String.fromCharCode(current | (c >> 7)));
+          output.push(f(current | (c >> 7)));
           current = (c&127) << 9;
           break;
         case 9:
-          output.push(String.fromCharCode(current | (c >> 6)));
+          output.push(f(current | (c >> 6)));
           current = (c&63) << 10;
           break;
         case 10:
-          output.push(String.fromCharCode(current | (c >> 5)));
+          output.push(f(current | (c >> 5)));
           current = (c&31) << 11;
           break;
         case 11:
-          output.push(String.fromCharCode(current | (c >> 4)));
+          output.push(f(current | (c >> 4)));
           current = (c&15) << 12;
           break;
         case 12:
-          output.push(String.fromCharCode(current | (c >> 3)));
+          output.push(f(current | (c >> 3)));
           current = (c&7) << 13;
           break;
         case 13:
-          output.push(String.fromCharCode(current | (c >> 2)));
+          output.push(f(current | (c >> 2)));
           current = (c&3) << 14;
           break;
         case 14:
-          output.push(String.fromCharCode(current | (c >> 1)));
+          output.push(f(current | (c >> 1)));
           current = (c&1) << 15;
           break;
         case 15:
-          output.push(String.fromCharCode(current | c));
+          output.push(f(current | c));
           status=0;
           break;
       }
@@ -172,20 +185,6 @@ var Base64String = {
     //return output;
 
   },
-
-
-  // private property
-  _keyStr : "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
-  _keyStrDec : this._keyStr.split(''),
-  _keyStrEnc : (function (){
-    // IIFE to create a dictionary
-    var dict = {}
-    var i = this._keyStrDec.length;
-    while(i--){
-      dict[this._keyStrDec[i]] = i;
-    }
-    return dict;
-  })(),
 
   decompress : function (input) {
     var output = [];
@@ -223,10 +222,10 @@ var Base64String = {
         enc4 = 64;
       }
 
-      output.push(this._keyStrDec[enc1]);
-      output.push(this._keyStrDec[enc2]);
-      output.push(this._keyStrDec[enc3]);
-      output.push(this._keyStrDec[enc4]);
+      output.push(keyStrDec[enc1]);
+      output.push(keyStrDec[enc2]);
+      output.push(keyStrDec[enc3]);
+      output.push(keyStrDec[enc4]);
     }
 
     return output.join('');
@@ -244,10 +243,10 @@ var Base64String = {
 
     while (i < input.length) {
 
-      enc1 = this._keyStrEnc[input.charAt(i++)];
-      enc2 = this._keyStrEnc[input.charAt(i++)];
-      enc3 = this._keyStrEnc[input.charAt(i++)];
-      enc4 = this._keyStrEnc[input.charAt(i++)];
+      enc1 = keyStrEnc[input.charAt(i++)];
+      enc2 = keyStrEnc[input.charAt(i++)];
+      enc3 = keyStrEnc[input.charAt(i++)];
+      enc4 = keyStrEnc[input.charAt(i++)];
 
       chr1 = (enc1 << 2) | (enc2 >> 4);
       chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
@@ -258,7 +257,7 @@ var Base64String = {
         flush = true;
 
         if (enc3 != 64) {
-          output.push(String.fromCharCode(output_ | chr2));
+          output.push(f(output_ | chr2));
           flush = false;
         }
         if (enc4 != 64) {
@@ -266,7 +265,7 @@ var Base64String = {
           flush = true;
         }
       } else {
-        output.push(String.fromCharCode(output_ | chr1));
+        output.push(f(output_ | chr1));
         flush = false;
 
         if (enc3 != 64) {
@@ -274,7 +273,7 @@ var Base64String = {
           flush = true;
         }
         if (enc4 != 64) {
-          output.push(String.fromCharCode(output_ | chr3));
+          output.push(f(output_ | chr3));
           flush = false;
         }
       }
@@ -282,14 +281,24 @@ var Base64String = {
     }
 
     if (flush) {
-      output.push(String.fromCharCode(output_));
+      output.push(f(output_));
       output = output.join('');
-      output = String.fromCharCode(output.charCodeAt(0)|256) + output.substring(1);
+      output = f(output.charCodeAt(0)|256) + output.substring(1);
     } else {
       output = output.join('');
     }
 
     return output;
 
-  }
+  },
+
+  compressToArray : function (input) {
+
+  },
+
+  decompressToArray : function (input) {
+
+  },
 }
+return Base64String;
+})()

--- a/libs/base64-string.js
+++ b/libs/base64-string.js
@@ -7,18 +7,18 @@
 // For more information, the home page:
 // http://pieroxy.net/blog/pages/lz-string/index.html
 //
-// Base64 compression / decompression for already compressed content (gif, png, jpg, mp3, ...) 
+// Base64 compression / decompression for already compressed content (gif, png, jpg, mp3, ...)
 // version 1.4.1
 var Base64String = {
-  
+
   compressToUTF16 : function (input) {
     var output = [],
         i,c,
         current,
         status = 0;
-    
+
     input = this.compress(input);
-    
+
     for (i=0 ; i<input.length ; i++) {
       c = input.charCodeAt(i);
       switch (status++) {
@@ -87,17 +87,17 @@ var Base64String = {
     output.push(String.fromCharCode(current + 32));
     return output.join('');
   },
-  
+
 
   decompressFromUTF16 : function (input) {
     var output = [],
         current,c,
         status=0,
         i = 0;
-    
+
     while (i < input.length) {
       c = input.charCodeAt(i) - 32;
-      
+
       switch (status++) {
         case 0:
           current = c << 1;
@@ -163,90 +163,100 @@ var Base64String = {
           status=0;
           break;
       }
-      
-      
+
+
       i++;
     }
-    
+
     return this.decompress(output.join(''));
     //return output;
-    
+
   },
 
 
   // private property
   _keyStr : "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
-  
+  _keyStrDec : this._keyStr.split(''),
+  _keyStrEnc : (function (){
+    // IIFE to create a dictionary
+    var dict = {}
+    var i = this._keyStrDec.length;
+    while(i--){
+      dict[this._keyStrDec[i]] = i;
+    }
+    return dict;
+  })(),
+
   decompress : function (input) {
     var output = [];
     var chr1, chr2, chr3, enc1, enc2, enc3, enc4;
     var i = 1;
     var odd = input.charCodeAt(0) >> 8;
-    
+
     while (i < input.length*2 && (i < input.length*2-1 || odd==0)) {
-      
+
       if (i%2==0) {
         chr1 = input.charCodeAt(i/2) >> 8;
         chr2 = input.charCodeAt(i/2) & 255;
-        if (i/2+1 < input.length) 
+        if (i/2+1 < input.length)
           chr3 = input.charCodeAt(i/2+1) >> 8;
-        else 
+        else
           chr3 = NaN;
       } else {
         chr1 = input.charCodeAt((i-1)/2) & 255;
         if ((i+1)/2 < input.length) {
           chr2 = input.charCodeAt((i+1)/2) >> 8;
           chr3 = input.charCodeAt((i+1)/2) & 255;
-        } else 
+        } else
           chr2=chr3=NaN;
       }
       i+=3;
-      
+
       enc1 = chr1 >> 2;
       enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
       enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
       enc4 = chr3 & 63;
-      
+
       if (isNaN(chr2) || (i==input.length*2+1 && odd)) {
         enc3 = enc4 = 64;
       } else if (isNaN(chr3) || (i==input.length*2 && odd)) {
         enc4 = 64;
       }
-      
-      output.push(this._keyStr.charAt(enc1));
-      output.push(this._keyStr.charAt(enc2));
-      output.push(this._keyStr.charAt(enc3));
-      output.push(this._keyStr.charAt(enc4));
+
+      output.push(this._keyStrDec[enc1]);
+      output.push(this._keyStrDec[enc2]);
+      output.push(this._keyStrDec[enc3]);
+      output.push(this._keyStrDec[enc4]);
     }
-    
+
     return output.join('');
   },
-  
+
   compress : function (input) {
     var output = [],
-        ol = 1, 
+        ol = 1,
         output_,
         chr1, chr2, chr3,
         enc1, enc2, enc3, enc4,
         i = 0, flush=false;
-    
+
     input = input.replace(/[^A-Za-z0-9\+\/\=]/g, "");
-    
+
     while (i < input.length) {
-      
-      enc1 = this._keyStr.indexOf(input.charAt(i++));
-      enc2 = this._keyStr.indexOf(input.charAt(i++));
-      enc3 = this._keyStr.indexOf(input.charAt(i++));
-      enc4 = this._keyStr.indexOf(input.charAt(i++));
-      
+
+      enc1 = this._keyStrEnc[input.charAt(i++)];
+      enc2 = this._keyStrEnc[input.charAt(i++)];
+      enc3 = this._keyStrEnc[input.charAt(i++)];
+      enc4 = this._keyStrEnc[input.charAt(i++)];
+
       chr1 = (enc1 << 2) | (enc2 >> 4);
       chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
       chr3 = ((enc3 & 3) << 6) | enc4;
-      
+
       if (ol%2==0) {
         output_ = chr1 << 8;
         flush = true;
-        
+
         if (enc3 != 64) {
           output.push(String.fromCharCode(output_ | chr2));
           flush = false;
@@ -258,7 +268,7 @@ var Base64String = {
       } else {
         output.push(String.fromCharCode(output_ | chr1));
         flush = false;
-        
+
         if (enc3 != 64) {
           output_ = chr2 << 8;
           flush = true;
@@ -270,7 +280,7 @@ var Base64String = {
       }
       ol+=3;
     }
-    
+
     if (flush) {
       output.push(String.fromCharCode(output_));
       output = output.join('');
@@ -278,8 +288,8 @@ var Base64String = {
     } else {
       output = output.join('');
     }
-    
+
     return output;
-    
+
   }
 }

--- a/libs/lz-string.js
+++ b/libs/lz-string.js
@@ -15,14 +15,14 @@ var keyStrBase64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234567
 var keyStrUriSafe = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-$";
 var baseReverseDic = {};
 
-function getBaseValue(alphabet, character) {
+function getReverseDic(alphabet){
   if (!baseReverseDic[alphabet]) {
     baseReverseDic[alphabet] = {};
     for (var i=0 ; i<alphabet.length ; i++) {
       baseReverseDic[alphabet][alphabet.charAt(i)] = i;
     }
   }
-  return baseReverseDic[alphabet][character];
+  return baseReverseDic[alphabet];
 }
 
 var LZString = {
@@ -41,7 +41,8 @@ var LZString = {
   decompressFromBase64 : function (input) {
     if (input == null) return "";
     if (input == "") return null;
-    return LZString._decompress(input.length, 32, function(index) { return getBaseValue(keyStrBase64, input.charAt(index)); });
+    var reverseDict = getReverseDic(keyStrBase64);
+    return LZString._decompress(input.length, 32, function(index) { return reverseDict[input.charAt(index)]; });
   },
 
   compressToUTF16 : function (input) {
@@ -100,7 +101,8 @@ var LZString = {
     if (input == null) return "";
     if (input == "") return null;
     input = input.replace(/ /g, "+");
-    return LZString._decompress(input.length, 32, function(index) { return getBaseValue(keyStrUriSafe, input.charAt(index)); });
+    var reverseDict = getReverseDic(keyStrUriSafe);
+    return LZString._decompress(input.length, 32, function(index) { return reverseDict[input.charAt(index)]; });
   },
 
   compress: function (uncompressed) {

--- a/libs/lz-string.js
+++ b/libs/lz-string.js
@@ -75,20 +75,10 @@ var LZString = {
   decompressFromUint8Array:function (compressed) {
     if (compressed===null || compressed===undefined){
         return LZString.decompressFromArray(compressed);
-    } else {
-        var buf=new Array(compressed.length/2); // 2 bytes per character
-        for (var i=0, TotalLen=buf.length; i<TotalLen; i++) {
-          buf[i]=compressed[i*2]*256+compressed[i*2+1];
-        }
-
-        var result = [];
-        buf.forEach(function (c) {
-          result.push(f(c));
-        });
-        return LZString.decompressFromArray(result);
-
+    } else if (compressed.length == 0){
+      return null;
     }
-
+    return LZString._decompress(compressed.length, 128, function (index) { return compressed[index]; });
   },
 
 

--- a/libs/lz-string.js
+++ b/libs/lz-string.js
@@ -11,15 +11,15 @@ var LZString = (function() {
 
 // private property
 var f = String.fromCharCode;
-var keyStrBase64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-var keyStrUriSafe = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-$";
+var keyStrBase64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".split('');
+var keyStrUriSafe = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-$".split('');
 var baseReverseDic = {};
 
-function getReverseDic(alphabet){
+function getReverseDict(alphabet){
   if (!baseReverseDic[alphabet]) {
     baseReverseDic[alphabet] = {};
     for (var i=0 ; i<alphabet.length ; i++) {
-      baseReverseDic[alphabet][alphabet.charAt(i)] = i;
+      baseReverseDic[alphabet][alphabet[i]] = i;
     }
   }
   return baseReverseDic[alphabet];
@@ -28,7 +28,7 @@ function getReverseDic(alphabet){
 var LZString = {
   compressToBase64 : function (input) {
     if (input == null) return "";
-    var res = LZString._compress(input, 6, function(a){return keyStrBase64.charAt(a);});
+    var res = LZString._compress(input, 6, function(a){return keyStrBase64[a];});
     switch (res.length % 4) { // To produce valid Base64
     default: // When could this happen ?
     case 0 : return res;
@@ -41,7 +41,7 @@ var LZString = {
   decompressFromBase64 : function (input) {
     if (input == null) return "";
     if (input == "") return null;
-    var reverseDict = getReverseDic(keyStrBase64);
+    var reverseDict = getReverseDict(keyStrBase64);
     return LZString._decompress(input.length, 32, function(index) { return reverseDict[input.charAt(index)]; });
   },
 
@@ -93,7 +93,7 @@ var LZString = {
   //compress into a string that is already URI encoded
   compressToEncodedURIComponent: function (input) {
     if (input == null) return "";
-    return LZString._compress(input, 6, function(a){return keyStrUriSafe.charAt(a);});
+    return LZString._compress(input, 6, function(a){return keyStrUriSafe[a];});
   },
 
   //decompress from an output of compressToEncodedURIComponent
@@ -101,7 +101,7 @@ var LZString = {
     if (input == null) return "";
     if (input == "") return null;
     input = input.replace(/ /g, "+");
-    var reverseDict = getReverseDic(keyStrUriSafe);
+    var reverseDict = getReverseDict(keyStrUriSafe);
     return LZString._decompress(input.length, 32, function(index) { return reverseDict[input.charAt(index)]; });
   },
 


### PR DESCRIPTION
This combines various suggestions from @Rycochet and @lishid and myself. See #88 and #97.

- replace string-based `keyStr.charAt(i)` with array-based `keyStr[i]`
- add `compressToArray` and `decompressFromArray` functions, and use them throughout the code to avoid intermediate string creation:
  - `compressToBase64` avoids appending to string
  - `compressToUint8Array` avoids an intermediate string
  - `decompressFromUint8Array` avoids an intermediate string

Similar optimisations have been applied to `base64-string.js`, but it doesn't have tests so I can't say for sure if it's bug-free.