### PR TITLE
Fixed safe uri alphabet (+$ -> _.) for compressToEncodedURIComponent/decompressToEncodedURIComponent

### DIFF
--- a/libs/lz-string.js
+++ b/libs/lz-string.js
@@ -12,7 +12,7 @@ var LZString = (function() {
 // private property
 var f = String.fromCharCode;
 var keyStrBase64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-var keyStrUriSafe = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-$";
+var keyStrUriSafe = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-.";
 var baseReverseDic = {};
 
 function getBaseValue(alphabet, character) {
@@ -99,7 +99,6 @@ var LZString = {
   decompressFromEncodedURIComponent:function (input) {
     if (input == null) return "";
     if (input == "") return null;
-    input = input.replace(/ /g, "+");
     return LZString._decompress(input.length, 32, function(index) { return getBaseValue(keyStrUriSafe, input.charAt(index)); });
   },
 


### PR DESCRIPTION
I don't know why '+' and '$' were chosen when this feature was implemented, but both characters need to be encoded for valid query strings. (`encodeURIComponent('+$') => '%2B%24'`)
So I changed them to '_' and '.' ... and also removed the +/whitespace replacement as it's not needed anymore.