### PR TITLE
fix(package.json): update license to reflect docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lz-string",
   "version": "1.4.4",
-  "license": "WTFPL",
+  "license": "MIT",
   "filename": "lz-string.js",
   "description": "LZ-based compression algorithm",
   "homepage": "http://pieroxy.net/blog/pages/lz-string/index.html",


### PR DESCRIPTION
matching MIT licensing found [here](https://github.com/pieroxy/lz-string/issues/119) and [here](http://pieroxy.net/blog/pages/lz-string/index.html#inline_menu_10)