### PR TITLE
Make lz-string tree-shakable for bundlers

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, test } from "vitest";
 
-import index from "../index";
+import * as index from "../index";
 
 describe("index.ts", () => {
     test("was the change deliberate?", ({ expect }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import {
 } from "./Uint8Array";
 import { compressToUTF16, decompressFromUTF16 } from "./UTF16";
 
-export default {
+export {
     _compress,
     _decompress,
     compress,


### PR DESCRIPTION
**Description:**

This pull request introduces a small but impactful change to the `lz-string` library to make it tree-shakable by modern bundlers. By modifying the entry point structure, this change enables a significant reduction in bundle size—over 30% when using esbuild without minification.

**Details:**

- **Before:** `import defaultExport from "lz-string"`
- **After:** `import * as defaultExport from "lz-string"`

This adjustment allows bundlers to effectively eliminate unused code, leading to leaner bundles. When using a single `compress`/`decompress` pair, this resulted in a 30% reduction in size. Although this change slightly alters how the library is imported, it offers considerable benefits in terms of performance and efficiency.
